### PR TITLE
Remove readonly access to getauthorizationtoken

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,6 @@ data "aws_iam_policy_document" "resource_readonly_access" {
     }
 
     actions = [
-      "ecr:GetAuthorizationToken",
       "ecr:BatchCheckLayerAvailability",
       "ecr:GetDownloadUrlForLayer",
       "ecr:GetRepositoryPolicy",


### PR DESCRIPTION
Breaking change mid-October. Fixed in cloudposse v0.28.1 but our codepipeline module is not yet compatible with AWS provider >=3.x
